### PR TITLE
Updated url to Akamai transaction url per Authorize.net change. Bumpe…

### DIFF
--- a/authorize-net.gemspec
+++ b/authorize-net.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.name         = 'authorize-net'
-  s.version      = '1.5.2'
+  s.version      = '1.5.3'
   s.add_dependency('nokogiri', '~> 1.4')
   s.summary      = "authorize.net ruby api"
   s.author = "asdf"

--- a/lib/authorize_net/xml_transaction.rb
+++ b/lib/authorize_net/xml_transaction.rb
@@ -8,7 +8,7 @@ module AuthorizeNet
     
     # Constants for both the various Authorize.Net subscription gateways are defined here.
     module Gateway
-      LIVE = 'https://api.authorize.net/xml/v1/request.api'
+      LIVE = 'https://api2.authorize.net/xml/v1/request.api'
       TEST = 'https://apitest.authorize.net/xml/v1/request.api'
     end
     


### PR DESCRIPTION
…d gem version. 
- Per Authorize.net's update [here](http://community.developer.authorize.net/t5/The-Authorize-Net-Developer-Blog/Important-Authorize-Net-Networking-Change/ba-p/51272?utm_campaign=2015%20Technical%20Newsletter%20to%20Merchants.html&utm_medium=email&utm_source=Eloqua), they are going to start routing their traffic through Akamai. 
- This is a required update that does not change any process on the backend.  
